### PR TITLE
修改属性值start为flex-start

### DIFF
--- a/flex.less
+++ b/flex.less
@@ -26,7 +26,7 @@
   display: flex;
   flex-direction: row;
 
-  & when ( @justify = start ) { justify-content: start; }
+  & when ( @justify = start ) { justify-content: flex-start; }
   & when ( @justify = center ) { justify-content: center; }
   & when ( @justify = end ) { justify-content: flex-end; }
   & when ( @justify = between ) { justify-content: space-between; }
@@ -48,7 +48,7 @@
   flex-wrap: wrap;
 
   & when ( @align = auto ) { align-content: initial; }
-  & when ( @align = top ) { align-content: start; }
+  & when ( @align = top ) { align-content: flex-start; }
   & when ( @align = middle ) { align-content: center; }
   & when ( @align = bottom ) { align-content: flex-end; }
   & when ( @align = between ) { align-content: space-between; }
@@ -69,7 +69,7 @@
   }
 
   & when ( @align = auto ) { align-self: initial; }
-  & when ( @align = top ) { align-self: start; }
+  & when ( @align = top ) { align-self: flex-start; }
   & when ( @align = middle ) { align-self: center; }
   & when ( @align = bottom ) { align-self: flex-end; }
   & when ( @align = full ) { height: auto; align-self: stretch; }
@@ -93,7 +93,7 @@
     .flexError(@align, 'flex-column')
   }
 
-  & when ( @justify = top ) { justify-content: start; }
+  & when ( @justify = top ) { justify-content: flex-start; }
   & when ( @justify = middle ) { justify-content: center; }
   & when ( @justify = bottom ) { justify-content: flex-end; }
   & when ( @justify = between ) { justify-content: space-between; }
@@ -108,7 +108,7 @@
   flex-wrap: wrap;
 
   & when ( @align = auto ) { align-content: initial; }
-  & when ( @align = start ) { align-content: start; }
+  & when ( @align = start ) { align-content: flex-start; }
   & when ( @align = center ) { align-content: center; }
   & when ( @align = end ) { align-content: flex-end; }
   & when ( @align = between ) { align-content: space-between; }
@@ -129,7 +129,7 @@
   }
 
   & when ( @align = auto ) { align-self: initial; }
-  & when ( @align = start ) { align-self: start; }
+  & when ( @align = start ) { align-self: flex-start; }
   & when ( @align = center ) { align-self: center; }
   & when ( @align = end ) { align-self: flex-end; }
   & when ( @align = full ) { width: auto; align-self: stretch; }

--- a/flex.sass
+++ b/flex.sass
@@ -24,7 +24,7 @@
   flex-direction: row
 
   @if $justify == start
-    justify-content: start
+    justify-content: flex-start
   @else if $justify == center
     justify-content: center
   @else if $justify == end
@@ -51,7 +51,7 @@
   @if $align == auto
     align-content: initial
   @else if $align == top
-    align-content: start
+    align-content: flex-start
   @else if $align == middle
     align-content: center
   @else if $align == bottom
@@ -75,7 +75,7 @@
   @if $align == auto
     align-self: initial
   @else if $align == top
-    align-self: start
+    align-self: flex-start
   @else if $align == middle
     align-self: center
   @else if $align == bottom
@@ -102,7 +102,7 @@
     +flexError($align, "flex-column")
 
   @if $justify == top
-    justify-content: start
+    justify-content: flex-start
   @else if $justify == middle
     justify-content: center
   @else if $justify == bottom
@@ -120,7 +120,7 @@
   @if $align == auto
     align-content: initial
   @else if $align == start
-    align-content: start
+    align-content: flex-start
   @else if $align == center
     align-content: center
   @else if $align == end
@@ -144,7 +144,7 @@
   @if $align == auto
     align-self: initial
   @else if $align == start
-    align-self: start
+    align-self: flex-start
   @else if $align == center
     align-self: center
   @else if $align == end

--- a/flex.scss
+++ b/flex.scss
@@ -26,7 +26,7 @@
   display: flex;
   flex-direction: row;
 
-  @if $justify == start { justify-content: start; }
+  @if $justify == start { justify-content: flex-start; }
   @else if $justify == center { justify-content: center; }
   @else if $justify == end { justify-content: flex-end; }
   @else if $justify == between { justify-content: space-between; }
@@ -48,7 +48,7 @@
   flex-wrap: wrap;
 
   @if $align == auto { align-content: initial; }
-  @else if $align == top { align-content: start; }
+  @else if $align == top { align-content: flex-start; }
   @else if $align == middle { align-content: center; }
   @else if $align == bottom { align-content: flex-end; }
   @else if $align == between { align-content: space-between; }
@@ -69,7 +69,7 @@
   }
 
   @if $align == auto { align-self: initial; }
-  @else if $align == top { align-self: start; }
+  @else if $align == top { align-self: flex-start; }
   @else if $align == middle { align-self: center; }
   @else if $align == bottom { align-self: flex-end; }
   @else if $align == full { height: auto; align-self: stretch; }
@@ -93,7 +93,7 @@
     @include flexError($align, 'flex-column');
   }
 
-  @if $justify == top { justify-content: start; }
+  @if $justify == top { justify-content: flex-start; }
   @else if $justify == middle { justify-content: center; }
   @else if $justify == bottom { justify-content: flex-end; }
   @else if $justify == between { justify-content: space-between; }
@@ -108,7 +108,7 @@
   flex-wrap: wrap;
 
   @if $align == auto { align-content: initial; }
-  @else if $align == start { align-content: start; }
+  @else if $align == start { align-content: flex-start; }
   @else if $align == center { align-content: center; }
   @else if $align == end { align-content: flex-end; }
   @else if $align == between { align-content: space-between; }
@@ -129,7 +129,7 @@
   }
 
   @if $align == auto { align-self: initial; }
-  @else if $align == start { align-self: start; }
+  @else if $align == start { align-self: flex-start; }
   @else if $align == center { align-self: center; }
   @else if $align == end { align-self: flex-end; }
   @else if $align == full { width: auto; align-self: stretch; }

--- a/flex.styl
+++ b/flex.styl
@@ -25,7 +25,7 @@ flex(justify = start, align = top)
   flex-direction: row
 
   if justify == start
-    justify-content: start
+    justify-content: flex-start
   else if justify == center
     justify-content: center
   else if justify == end
@@ -53,7 +53,7 @@ flex-wrap(align = top)
   if align == auto
     align-content: initial
   else if align == top
-    align-content: start
+    align-content: flex-start
   else if align == middle
     align-content: center
   else if align == bottom
@@ -80,7 +80,7 @@ flex-self(flex = auto, align = auto)
   if align == auto
     align-self: initial
   else if align == top
-    align-self: start
+    align-self: flex-start
   else if align == middle
     align-self: center
   else if align == bottom
@@ -109,7 +109,7 @@ flex-column(align = start, justify = top)
     flexError(align, "flex-column")
 
   if justify == top
-    justify-content: start
+    justify-content: flex-start
   else if justify == middle
     justify-content: center
   else if justify == bottom
@@ -128,7 +128,7 @@ flex-column-wrap(align = start)
   if align == auto
     align-content: initial
   else if align == start
-    align-content: start
+    align-content: flex-start
   else if align == center
     align-content: center
   else if align == end
@@ -155,7 +155,7 @@ flex-column-self(flex = auto, align = auto)
   if align == auto
     align-self: initial
   else if align == start
-    align-self: start
+    align-self: flex-start
   else if align == center
     align-self: center
   else if align == end


### PR DESCRIPTION
在`justify-content`、` align-content`、`align-self`中css属性中使用`start`与`flex-start`属性值效果相同。建议使用规范的`flex-start`，在部分样式加载器中使用`flex`属性值会报警告。